### PR TITLE
Add provided scope to ProtocolLib dependency

### DIFF
--- a/ServerListMotd-Spigot/pom.xml
+++ b/ServerListMotd-Spigot/pom.xml
@@ -29,6 +29,7 @@
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
             <version>4.5.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>


### PR DESCRIPTION
Removes ProtocolLib from the final jar file, reducing file size and fixes potential compatibility problems.

See https://www.spigotmc.org/threads/serverlistmotd-revitalized.461164/#post-4166269